### PR TITLE
Update gdx_analytics_drupal_snowplow.module

### DIFF
--- a/gdx_analytics_drupal_snowplow.module
+++ b/gdx_analytics_drupal_snowplow.module
@@ -39,7 +39,6 @@ function gdx_analytics_drupal_snowplow_page_attachments(array &$page) {
     $page['#attached']['library'][] = 'gdx_analytics_drupal_snowplow/gdx_analytics_drupal_snowplow.webtracker_search';
   } else {
     $page['#attached']['drupalSettings']['script_uri'] = $script_uri;
-    $page['#attached']['library'][] = 'gdx_analytics_drupal_snowplow/gdx_analytics_drupal_snowplow.webtracker_search';
     $page['#attached']['library'][] = 'gdx_analytics_drupal_snowplow/gdx_analytics_drupal_snowplow.webtracker'; 
   }
 }


### PR DESCRIPTION
Removed call to load unnecessary js library to prevent both trackers from loading. The webtracker_search library should not be getting attached in the else block here.