### PR TITLE
Gdxdsd 7869 declare search key

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This module requires Drupal 10. Backwards compatibility tests are also conducted
 
 This project is currently under development and actively supported by the GDX Analytics Team.
 
-The latest version released is 4.0.0.
+This version: 4.0.0
 
-This is a Drupal 10 version with the option to declare a specific Search Key. The module looks for the Search Path(s) to trigger a search event and extracts the search terms from the URI based on the defined Search Key. It's important to note that this is a breaking feature, as previous version extracted search terms from the first key-value pair in the URI.
+This version, tested in Drupal 10, adds the option to declare a specific Search Key. The module looks for the Search Path(s) to trigger a search event and extracts the search terms from the URI based on the defined Search Key. It's important to note that this is a breaking feature, as previous version extracted search terms from the first key-value pair in the URI.
 
 Older versions:
 
@@ -52,13 +52,11 @@ Configure settings in Administration » Configuration » GDX Analytics Drupal Sn
     
 Use this configuration page to set the Collector Environment, Tracking Script URI, App ID, Search Path and Search Key.
 
-The default settings for GDX Analytics development data pipeline are:
+Use the values provided by The GDX Analytics Team for:
 
-- Collector Environment = spm.apps.gov.bc.ca
-
-- Snowplow tracking script URI = https://www2.gov.bc.ca/StaticWebResources/static/sp/sp-2-14-0.js
-
-- App ID = Snowplow_standalone
+- Collector Environment
+- Snowplow tracking script URI
+- App ID
 
 If the Snowplow Search Event is enabled, the module looks for the Search Path to trigger a search event and extracts the search terms from the URI using the defined Search Key:
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This module requires Drupal 10. Backwards compatibility tests are also conducted
 
 This project is currently under development and actively supported by the GDX Analytics Team.
 
-The current version released is 3.3.0. 
+The current version released is 3.4.0. 
 
-Versions 3.1.0 and newer allow the GDX Analytics Drupal Snowplow module to be used alongside other search modules, such as Drupal Search API.
+Versions 3.1.0 and later allow the GDX Analytics Drupal Snowplow module to be used alongside other search modules, such as Drupal Search API.
   
 ## Relevant Repositories
 [GDX-Analytics/](https://github.com/bcgov/GDX-Analytics/)
@@ -23,19 +23,39 @@ This is the central repository for work by the GDX Analytics Team.
 
 ## Installation
  
-Install as you would normally install a contributed Drupal module. Visit: https://www.drupal.org/docs/extending-drupal/installing-modules for further information.
+Install as you would typically install a contributed Drupal module. Visit: https://www.drupal.org/docs/extending-drupal/installing-modules for further information.
 
 Change directories to your sites/modules/custom folder in your drupal installation.
   
-Clone the project from github: https://github.com/bcgov/GDX-Analytics-Drupal-Snowplow.
+Clone the project from GitHub: https://github.com/bcgov/GDX-Analytics-Drupal-Snowplow.
   
-Install the module in Administration » Extend. Select the modul, then scroll down and click Install.
+Install the module in Administration » Extend. Select the module, then scroll down and click Install.
 
 ## Configuration
 
 Configure settings in Administration » Configuration » GDX Analytics Drupal Snowplow settings.
     
-Use this Configuration page to set the collector environment, tracking script URI, app ID and search path.
+Use this configuration page to set the collector environment, tracking script URI, app ID, search path and search key.
+
+The default settings for GDX Analytics development data pipeline are:
+
+- Collector Environment = spm.apps.gov.bc.ca
+
+- Snowplow tracking script URI = https://www2.gov.bc.ca/StaticWebResources/static/sp/sp-2-14-0.js
+
+- App ID = Snowplow_standalone
+
+If the Snowplow Search Event is enabled, the module look for the Search Path to trigger a search event and extract the search terms from the URI using the defined Search Key:
+
+- Search Path = Enter the search path(s) required to trigger a search event. If you want to use multiple paths, use comma-separated values (Example: '/search1, /search2'). 
+
+- Search Key = Enter the search key required to extract search terms. If there are multiple copies of the same key in the URI (Example: .../search/node?keys=value1&keys=value2), the module will concatenate all key values to the list of search terms.
+
+In Drupal, the standard search URI has the following structure:
+
+```https://.../search/node?keys=value```
+
+The default path for the module is set to‘/search,’ and the default search key is set to ‘keys.’ 
 
 ## Getting Help or Reporting an Issue
  
@@ -43,13 +63,13 @@ For any questions regarding this project, or for inquiries about starting a new 
 
 ## Contributors
 
-The GDX Analytics Team are the main contributors to this project and maintain the code.
+The GDX Analytics Team is the main contributor to this project and maintains the code.
 
 ## How to Contribute
 
 If you would like to contribute, please see our [CONTRIBUTING](CONTRIBUTING.md) guidelines.
 
-Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project, you agree to abide by its terms.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The default settings for GDX Analytics development data pipeline are:
 
 - App ID = Snowplow_standalone
 
-If the Snowplow Search Event is enabled, the module looks for the Search Path to trigger a search event and extract the search terms from the URI using the defined Search Key:
+If the Snowplow Search Event is enabled, the module looks for the Search Path to trigger a search event and extracts the search terms from the URI using the defined Search Key:
 
 - Search Path = Enter the search path(s) required to trigger a search event. If you want to use multiple paths, use comma-separated values (Example: '/search1, /search2'). 
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,19 @@ This project is currently under development and actively supported by the GDX An
 
 This version: 4.0.0
 
-This version, tested in Drupal 10, adds the option to declare a specific Search Key. The module looks for the Search Path(s) to trigger a search event and extracts the search terms from the URI based on the defined Search Key. It's important to note that this is a breaking feature, as previous version extracted search terms from the first key-value pair in the URI.
+This version, tested in Drupal 10/9/8, adds the option to declare a specific Search Key. The module looks for the Search Path(s) to trigger a search event and extracts the search terms from the URI based on the defined Search Key. If there are multiple copies of the same key in the URI, the module will concatenate all key values to the list of search terms.
+
+It's important to note that this is a breaking feature, as previous version extracted search terms from the first key-value pair in the URI.
 
 Older versions:
 
-3.3.0: Drupal 10 version with multiple (comma-separated) search paths available. It is possible to configure the module to trigger a search event coming from different search paths.
+3.3.0: Tested in Drupal 10/9/8, this version adds the option of using multiple (comma-separated) search paths. It is possible to configure the module to trigger a search event coming from different search paths.
 
-3.2.0: Drupal 10 version with collector field validation updates.
+3.2.0: Tested in Drupal 10/9/8, this version updates collector field validation.
 
-3.1.0: Drupal 10 version compatible with Drupal search modules, including Search API. There are no hard-coded configurations anymore. The module looks for the Search Path to trigger a search event and extracts the search terms from the first key-value pair of the URI.
+3.1.0: Tested in Drupal 10/9/8, this version adds compatiblity with Drupal search modules, including Search API. There are no hard-coded configurations anymore. The module looks for the Search Path to trigger a search event and extracts the search terms from the first key-value pair of the URI.
 
-3.0.0: Drupal 10 version, backward tested with Drupal 9 & 8. This version reverts to using Drupal standard search and is not compatible with Search API.
+3.0.0: Tested in Drupal 10/9/8, this version reverts to using Drupal standard search and is not compatible with Search API.
 
 2.0.0: Drupal 9 version with clean-up configuration page and a toggle for search/no-search. This version works with Drupal Search API but not the Standard Search.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The default settings for GDX Analytics development data pipeline are:
 
 - App ID = Snowplow_standalone
 
-If the Snowplow Search Event is enabled, the module look for the Search Path to trigger a search event and extract the search terms from the URI using the defined Search Key:
+If the Snowplow Search Event is enabled, the module looks for the Search Path to trigger a search event and extract the search terms from the URI using the defined Search Key:
 
 - Search Path = Enter the search path(s) required to trigger a search event. If you want to use multiple paths, use comma-separated values (Example: '/search1, /search2'). 
 
@@ -55,7 +55,7 @@ In Drupal, the standard search URI has the following structure:
 
 ```https://.../search/node?keys=value```
 
-The default path for the module is set to‘/search,’ and the default search key is set to ‘keys.’ 
+The default Search Path for the module is set to‘/search,’ and the default Search Key is set to ‘keys.’ 
 
 ## Getting Help or Reporting an Issue
  

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This module requires Drupal 10. Backwards compatibility tests are also conducted
 
 This project is currently under development and actively supported by the GDX Analytics Team.
 
-The latest version released is X.X.0.
+The latest version released is 4.0.0.
 
-This is a Drupal 10 version with the option to declare a specific Search Key. The module looks for the Search Path(s) to trigger a search event and extracts the search terms from the URI based on the defined Search Key.
+This is a Drupal 10 version with the option to declare a specific Search Key. The module looks for the Search Path(s) to trigger a search event and extracts the search terms from the URI based on the defined Search Key. It's important to note that this is a breaking feature, as previous version extracted search terms from the first key-value pair in the URI.
 
 Older versions:
 
@@ -22,9 +22,9 @@ Older versions:
 
 3.2.0: Drupal 10 version with collector field validation updates.
 
-3.1.0: Drupal 10 version backward tested with Drupal 9. This version is compatible with Drupal search modules, including Search API. There are no hard-coded configurations anymore. The module looks for the Search Path to trigger a search event and extracts the search terms from the first key-value pair of the URI.
+3.1.0: Drupal 10 version compatible with Drupal search modules, including Search API. There are no hard-coded configurations anymore. The module looks for the Search Path to trigger a search event and extracts the search terms from the first key-value pair of the URI.
 
-3.0.0: Drupal 10 version compatible with Drupal 9 & 8. This version reverts to using Drupal standard search and is not compatible with Search API.
+3.0.0: Drupal 10 version, backward tested with Drupal 9 & 8. This version reverts to using Drupal standard search and is not compatible with Search API.
 
 2.0.0: Drupal 9 version with clean-up configuration page and a toggle for search/no-search. This version works with Drupal Search API but not the Standard Search.
 
@@ -50,7 +50,7 @@ Install the module in Administration » Extend. Select the module, then scroll d
 
 Configure settings in Administration » Configuration » GDX Analytics Drupal Snowplow settings.
     
-Use this configuration page to set the collector environment, tracking script URI, app ID, search path and search key.
+Use this configuration page to set the Collector Environment, Tracking Script URI, App ID, Search Path and Search Key.
 
 The default settings for GDX Analytics development data pipeline are:
 
@@ -62,9 +62,9 @@ The default settings for GDX Analytics development data pipeline are:
 
 If the Snowplow Search Event is enabled, the module looks for the Search Path to trigger a search event and extracts the search terms from the URI using the defined Search Key:
 
-- Search Path = Enter the search path(s) required to trigger a search event. If you want to use multiple paths, use comma-separated values (Example: '/search1, /search2'). 
+- Search Path = Enter the search path(s) required to trigger a search event. If you want to use multiple paths, use comma-separated values, e.g, "/search1, /search2".
 
-- Search Key = Enter the search key required to extract search terms. If there are multiple copies of the same key in the URI (Example: .../search/node?keys=value1&keys=value2), the module will concatenate all key values to the list of search terms.
+- Search Key = Enter the search key required to extract search terms. If there are multiple copies of the same key in the URI, the module will concatenate all key values to the list of search terms. For example, the search terms extracted from "/search/node?keys=value1&keys=value2" will be (value1, value2) when the Search Path is set to "/search" and the Search Key is set to "keys".
 
 In Drupal, the standard search URI has the following structure:
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,25 @@ This module requires Drupal 10. Backwards compatibility tests are also conducted
 
 This project is currently under development and actively supported by the GDX Analytics Team.
 
-The current version released is 3.4.0. 
+The latest version released is X.X.0.
 
-Versions 3.1.0 and later allow the GDX Analytics Drupal Snowplow module to be used alongside other search modules, such as Drupal Search API.
+This is a Drupal 10 version with the option to declare a specific Search Key. The module looks for the Search Path(s) to trigger a search event and extracts the search terms from the URI based on the defined Search Key.
+
+Older versions:
+
+3.3.0: Drupal 10 version with multiple (comma-separated) search paths available. It is possible to configure the module to trigger a search event coming from different search paths.
+
+3.2.0: Drupal 10 version with collector field validation updates.
+
+3.1.0: Drupal 10 version backward tested with Drupal 9. This version is compatible with Drupal search modules, including Search API. There are no hard-coded configurations anymore. The module looks for the Search Path to trigger a search event and extracts the search terms from the first key-value pair of the URI.
+
+3.0.0: Drupal 10 version compatible with Drupal 9 & 8. This version reverts to using Drupal standard search and is not compatible with Search API.
+
+2.0.0: Drupal 9 version with clean-up configuration page and a toggle for search/no-search. This version works with Drupal Search API but not the Standard Search.
+
+1.0.0: First working version. The Drupal 8 module has been revised to work with Drupal 9, utilizing hard-coded configuration.
   
+
 ## Relevant Repositories
 [GDX-Analytics/](https://github.com/bcgov/GDX-Analytics/)
 

--- a/config/install/gdx_analytics_drupal_snowplow.settings.yml
+++ b/config/install/gdx_analytics_drupal_snowplow.settings.yml
@@ -3,3 +3,4 @@ gdx_analytics_snowplow_version:
 gdx_analytics_snowplow_script_uri:
 gdx_analytics_app_id:
 gdx_analytics_search_path: /search # default search path for standard search
+gdx_analytics_search_key: keys # default search key for standard search

--- a/gdx_analytics_drupal_snowplow.info.yml
+++ b/gdx_analytics_drupal_snowplow.info.yml
@@ -4,4 +4,4 @@ description: 'Configures the Javascript tracker for the BC Government GDX Analyt
 core: 8.x
 core_version_requirement: ^8 || ^9 || ^10
 package: 'Analytics'
-version: '3.3.0'
+version: '3.4.0'

--- a/gdx_analytics_drupal_snowplow.info.yml
+++ b/gdx_analytics_drupal_snowplow.info.yml
@@ -4,4 +4,4 @@ description: 'Configures the Javascript tracker for the BC Government GDX Analyt
 core: 8.x
 core_version_requirement: ^8 || ^9 || ^10
 package: 'Analytics'
-version: '3.4.0'
+version: '4.0.0'

--- a/gdx_analytics_drupal_snowplow.libraries.yml
+++ b/gdx_analytics_drupal_snowplow.libraries.yml
@@ -1,5 +1,5 @@
 gdx_analytics_drupal_snowplow.webtracker:
-  version: 3.4.0
+  version: 4.0.0
   header: true
   js: 
     js/SnowplowInlineCode.js: {}
@@ -7,7 +7,7 @@ gdx_analytics_drupal_snowplow.webtracker:
     - core/drupalSettings
 
 gdx_analytics_drupal_snowplow.webtracker_search:
-  version: 3.4.0
+  version: 4.0.0
   header: true
   js: 
     js/SnowplowInlineCodeSearch.js: {}

--- a/gdx_analytics_drupal_snowplow.libraries.yml
+++ b/gdx_analytics_drupal_snowplow.libraries.yml
@@ -1,5 +1,5 @@
 gdx_analytics_drupal_snowplow.webtracker:
-  version: 3.3.0
+  version: 3.4.0
   header: true
   js: 
     js/SnowplowInlineCode.js: {}
@@ -7,7 +7,7 @@ gdx_analytics_drupal_snowplow.webtracker:
     - core/drupalSettings
 
 gdx_analytics_drupal_snowplow.webtracker_search:
-  version: 3.3.0
+  version: 3.4.0
   header: true
   js: 
     js/SnowplowInlineCodeSearch.js: {}

--- a/gdx_analytics_drupal_snowplow.links.menu.yml
+++ b/gdx_analytics_drupal_snowplow.links.menu.yml
@@ -1,7 +1,7 @@
 gdx_analytics_drupal_snowplow.gdx_analytics_drupal_snowplow_settings_form:
   title: 'GDX Analytics Drupal Snowplow settings'
   route_name: gdx_analytics_drupal_snowplow.gdx_analytics_drupal_snowplow_settings_form
-  description: 'Configure the collector environment, tracking script URI, app ID, and whether searches are tracked.'
+  description: 'Configure the collector environment, tracking script URI, app ID, and whether searches are tracked using a search path and key.'
   parent: system.admin_config_system
   weight: 99
 

--- a/gdx_analytics_drupal_snowplow.module
+++ b/gdx_analytics_drupal_snowplow.module
@@ -140,7 +140,7 @@ function handleTrackerWithSearch(&$page, $settings) {
     // Use below to print to browser console
     // echo '<script>console.log("All keys:", ' . json_encode($all_keys) . ');</script>';
 
-    // Extract the search query parameters from the URI (using the specified search key)
+    // Extract the search terms from the keys array
     if (!empty($all_keys)) {
       //Join the elements into a single string, then split back using space as delimiter
         $search_terms = implode(' ', $all_keys);

--- a/gdx_analytics_drupal_snowplow.module
+++ b/gdx_analytics_drupal_snowplow.module
@@ -128,6 +128,7 @@ function handleTrackerWithSearch(&$page, $settings) {
     $params = explode('&', $query_string);
 
     // Extract all values for the given key
+    // This also checks for multiple key usage (such as /search/node?keys=test1+test2&keys=test3)
     $all_keys = [];
     foreach ($params as $param) {
         list($key, $value) = explode('=', $param);
@@ -135,6 +136,9 @@ function handleTrackerWithSearch(&$page, $settings) {
             $all_keys[] = urldecode($value);
         }
     }
+
+    // Use below to print to browser console
+    // echo '<script>console.log("All keys:", ' . json_encode($all_keys) . ');</script>';
 
     // Extract the search query parameters from the URI (using the specified search key)
     if (!empty($all_keys)) {

--- a/gdx_analytics_drupal_snowplow.module
+++ b/gdx_analytics_drupal_snowplow.module
@@ -90,6 +90,7 @@ function handleNonAdminRoutes(&$page, $logger) {
       'app_id' => $settings['gdx_analytics_app_id'],
       'snowplow_version' => $settings['gdx_analytics_snowplow_version'],
       'search_path' => $settings['gdx_analytics_search_path'],
+      'search_key' => $settings['gdx_analytics_search_key']
     ];
 
     // Attach the main tracking code url.
@@ -127,12 +128,17 @@ function handleTrackerWithSearch(&$page, $settings) {
 
   // Check if any of the search paths are in the URL
   if ($is_search_page) {
-    // Extract the search query parameters from the URI (value of the first key)
-    $search_terms = reset($_GET);
-    if (!empty($search_terms)) {
-      $page['#attached']['drupalSettings']['search'] = true;
-      // Assign the array of individual search terms (use space as delimiter)
-      $page['#attached']['drupalSettings']['search_terms'] = explode(' ', $search_terms);
+
+    $search_key = $settings['gdx_analytics_search_key'];
+
+    // Extract the search query parameters from the URI (using the specified search key)
+    if (!empty($_GET[$search_key])) {
+      $search_terms = $_GET[$search_key];
+      if (!empty($search_terms)) {
+        $page['#attached']['drupalSettings']['search'] = true;
+        // Assign the array of individual search terms (use space as delimiter)
+        $page['#attached']['drupalSettings']['search_terms'] = explode(' ', $search_terms);
+      }
     }
   }
   // Attach the tracking code to front-end pages if the search toggle is enabled

--- a/gdx_analytics_drupal_snowplow.module
+++ b/gdx_analytics_drupal_snowplow.module
@@ -128,7 +128,7 @@ function handleTrackerWithSearch(&$page, $settings) {
     $params = explode('&', $query_string);
 
     // Extract all values for the given key
-    // This also checks for multiple key usage (such as /search/node?keys=test1+test2&keys=test3)
+    // This also checks for multiple use of the same key (Example: /search/node?keys=test1+test2&keys=test3)
     $all_keys = [];
     foreach ($params as $param) {
         list($key, $value) = explode('=', $param);
@@ -136,9 +136,6 @@ function handleTrackerWithSearch(&$page, $settings) {
             $all_keys[] = urldecode($value);
         }
     }
-
-    // Use below to print to browser console
-    // echo '<script>console.log("All keys:", ' . json_encode($all_keys) . ');</script>';
 
     // Extract the search terms from the keys array
     if (!empty($all_keys)) {

--- a/gdx_analytics_drupal_snowplow.module
+++ b/gdx_analytics_drupal_snowplow.module
@@ -8,24 +8,14 @@
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 
-// Define constants for route names.
+// Constants
 define('GDX_ANALYTICS_SETTINGS_FORM_ROUTE', 'gdx_analytics_drupal_snowplow.gdx_analytics_drupal_snowplow_settings_form');
 define('GDX_ANALYTICS_HELP_PAGE_ROUTE', 'help.page.gdx_analytics_drupal_snowplow');
-
-// Define constant for tracker versions.
 define('GDX_ANALYTICS_WEBTRACKER', 'gdx_analytics_drupal_snowplow/gdx_analytics_drupal_snowplow.webtracker');
 define('GDX_ANALYTICS_WEBTRACKER_WITH_SEARCH', 'gdx_analytics_drupal_snowplow/gdx_analytics_drupal_snowplow.webtracker_search');
-
-// Define constant for configuration name.
 define('GDX_ANALYTICS_CONFIG_NAME', 'gdx_analytics_drupal_snowplow.settings');
-
-// Define constant for warning message about incomplete configuration.
 define('GDX_ANALYTICS_WARNING_CONFIG', t('Please Configure Your GDX Analytics Drupal Snowplow Module.<br>For assistance with filling out this form, contact the GDX Analytics Team.'));
-
-// Define constant for warning message about configuring the module.
 define('GDX_ANALYTICS_WARNING_CONFIG_LINK', 'Please click here to configure your GDX Analytics Drupal Snowplow module.');
-
-// Define constant for the module description.
 define('GDX_ANALYTICS_MODULE_DESCRIPTION', t('This is the GDX Analytics Drupal Snowplow module.'));
 
 
@@ -131,13 +121,30 @@ function handleTrackerWithSearch(&$page, $settings) {
 
     $search_key = $settings['gdx_analytics_search_key'];
 
+    // Extract query string from the full URI
+    $query_string = parse_url($curr_uri, PHP_URL_QUERY);
+
+    // Split query string by '&' to get key-value pairs
+    $params = explode('&', $query_string);
+
+    // Extract all values for the given key
+    $all_keys = [];
+    foreach ($params as $param) {
+        list($key, $value) = explode('=', $param);
+        if ($key == $search_key) {
+            $all_keys[] = urldecode($value);
+        }
+    }
+
     // Extract the search query parameters from the URI (using the specified search key)
-    if (!empty($_GET[$search_key])) {
-      $search_terms = $_GET[$search_key];
+    if (!empty($all_keys)) {
+      //Join the elements into a single string, then split back using space as delimiter
+        $search_terms = implode(' ', $all_keys);
+        $search_terms = explode(' ', $search_terms);
       if (!empty($search_terms)) {
+        // Assign the array of individual search terms
         $page['#attached']['drupalSettings']['search'] = true;
-        // Assign the array of individual search terms (use space as delimiter)
-        $page['#attached']['drupalSettings']['search_terms'] = explode(' ', $search_terms);
+        $page['#attached']['drupalSettings']['search_terms'] = $search_terms;
       }
     }
   }

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -112,13 +112,21 @@ class SettingsForm extends ConfigFormBase {
     }
 
     // Validate search key to ensure it is not empty and contain valid characters
-    $search_key = trim($form_state->getValue('gdx_analytics_search_key'));
+    $original_value = $form_state->getValue('gdx_analytics_search_key');
+    $search_key = trim($original_value);
     $valid_key_regex = '/^[a-zA-Z0-9_-]+$/';
-    if (empty($search_key) || !preg_match($valid_key_regex, $search_key)) {
-      $form_state->setErrorByName(
-        'gdx_analytics_search_key',
-        $this->t('Search key cannot be empty and must contain valid characters.')
-      );
+
+    if ($original_value !== $search_key || empty($search_key) || !preg_match($valid_key_regex, $search_key)) {
+      $form_state->setErrorByName('gdx_analytics_search_key', $this->t('Search key cannot be empty, have leading/trailing spaces, or contain invalid characters.'));
+    }
+
+    // Validate App ID to ensure it is not empty and contain valid characters
+    $original_value = $form_state->getValue('gdx_analytics_app_id');
+    $app_id= trim($original_value);
+    $valid_key_regex = '/^[a-zA-Z0-9_-]+$/';
+
+    if ($original_value !== $app_id || empty($app_id) || !preg_match($valid_key_regex, $app_id)) {
+      $form_state->setErrorByName('gdx_analytics_app_id', $this->t('App ID cannot be empty, have leading/trailing spaces, or contain invalid characters.'));
     }
 
     // Validate the Snowplow tracking script URI to ensure it's a complete URL with 'http://' or 'https://'.

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -68,6 +68,15 @@ class SettingsForm extends ConfigFormBase {
       '#size' => 60,
       '#required' => true,
     ];
+    $form['gdx_analytics_search_key'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Search Key'),
+      '#default_value' => $config->get('gdx_analytics_search_key'),
+      '#description' => $this->t('Enter the search key required for your search module.'),
+      '#maxlength' => 256,
+      '#size' => 60,
+      '#required' => true,
+    ];
     $form['gdx_analytics_snowplow_version'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Snowplow Search Event'),

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -111,6 +111,16 @@ class SettingsForm extends ConfigFormBase {
       }
     }
 
+    // Validate search key to ensure it is not empty and contain valid characters
+    $search_key = trim($form_state->getValue('gdx_analytics_search_key'));
+    $valid_key_regex = '/^[a-zA-Z0-9_-]+$/';
+    if (empty($search_key) || !preg_match($valid_key_regex, $search_key)) {
+      $form_state->setErrorByName(
+        'gdx_analytics_search_key',
+        $this->t('Search key cannot be empty and must contain valid characters.')
+      );
+    }
+
     // Validate the Snowplow tracking script URI to ensure it's a complete URL with 'http://' or 'https://'.
     $script_uri = $form_state->getValue('gdx_analytics_snowplow_script_uri');
     if (!empty($script_uri) && !filter_var($script_uri, FILTER_VALIDATE_URL) && substr($script_uri, 0, 1) !== 'http') {
@@ -139,6 +149,7 @@ class SettingsForm extends ConfigFormBase {
         ->set('gdx_analytics_snowplow_script_uri', $form_state->getValue('gdx_analytics_snowplow_script_uri'))
         ->set('gdx_analytics_app_id', $form_state->getValue('gdx_analytics_app_id'))
         ->set('gdx_analytics_search_path', $form_state->getValue('gdx_analytics_search_path'))
+        ->set('gdx_analytics_search_key', $form_state->getValue('gdx_analytics_search_key'))
         ->save();
       
       // Drupal will provide "The configuration options have been saved." message

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -72,7 +72,7 @@ class SettingsForm extends ConfigFormBase {
       '#type' => 'textfield',
       '#title' => $this->t('Search Key'),
       '#default_value' => $config->get('gdx_analytics_search_key'),
-      '#description' => $this->t('Enter the search key required for your search module.'),
+      '#description' => $this->t('Enter the search key required for your search configuration.'),
       '#maxlength' => 256,
       '#size' => 60,
       '#required' => true,


### PR DESCRIPTION
This PR:

edits handleTrackerWithSearch function in “gdx_analytics_drupal_snowplow.module” to use a search key to extract search terms

adds form validation for search key (and app id ) in “SettingsForm.php”

edits version numbering, module description and the Readme in line with the recent changes

See the ticket comment for testing instructions