### PR TITLE
Bugfixes

### DIFF
--- a/gdx_analytics_drupal_snowplow.info.yml
+++ b/gdx_analytics_drupal_snowplow.info.yml
@@ -5,3 +5,4 @@ core: 8.x
 core_version_requirement: ^8 || ^9 || ^10
 package: 'Analytics'
 version: '4.1.0'
+configure: gdx_analytics_drupal_snowplow.gdx_analytics_drupal_snowplow_settings_form

--- a/gdx_analytics_drupal_snowplow.module
+++ b/gdx_analytics_drupal_snowplow.module
@@ -57,6 +57,7 @@ function handleAdminRoutes($logger, $messenger) {
   
   // Check if configuration is incomplete and display appropriate message.
   if (isConfigurationIncomplete($logger, $messenger)) {
+    $route_name = \Drupal::routeMatch()->getRouteName();
     if ($route_name === GDX_ANALYTICS_SETTINGS_FORM_ROUTE) {
       $messenger->addWarning(GDX_ANALYTICS_WARNING_CONFIG);
     } else {


### PR DESCRIPTION
Two small fixes:

- The first is a bug fix: The warning message GDX_ANALYTICS_WARNING_CONFIG will _never_ be displayed, without this fix.
- The second is to add this 'configure' link to the standard list-of-modules page, to make it easier to find the Snowplow module's config form, and easier to get to it.
<img width="675" height="320" alt="image" src="https://github.com/user-attachments/assets/1772286d-bf87-4595-9456-a93393bb263e" />
